### PR TITLE
Fix SpaNet Wall Checkpoint Name

### DIFF
--- a/src/food_detector/spa_demo_config.py
+++ b/src/food_detector/spa_demo_config.py
@@ -33,7 +33,7 @@ spanet_checkpoint = os.path.join(
     'checkpoint/spanet_ckpt.pth')#food_spanet_all_rgb_wall_wo_celery_carrot_bell_pepper_ckpt_best.pth')
 spanet_wall_checkpoint = os.path.join(
     bsp_path,
-    'checkpoint/food_spanet_all_rgb_wall_dr_ckpt_best.pth')#'checkpoint/spanet_with_wall_ckpt.pth')  # DEBUG: XM 
+    'checkpoint/spanet_wall.pth')
 
 pred_position = [0.5, 0.5]
 


### PR DESCRIPTION
The code currently expects a `bite_selection_package` checkpoint called [food_spanet_all_rgb_wall_dr_ckpt_best.pth](https://github.com/personalrobotics/food_detector/blob/75b1fc7aff572b96cf2744f7d5d9c6615f610bea/src/food_detector/spa_demo_config.py#L36). However, that checkpoint doesn't get installed by [bite_selection_package/load_checkpoint.sh](https://github.com/personalrobotics/bite_selection_package/blob/f44f1f30738e50722fa851177258d859d5638baa/load_checkpoint.sh#L11). I believe the intended checkpoint was `spanet_wall.pth`. This PR addresses the mis-named default checkpoint.